### PR TITLE
setup: Update url in metadata to new repository

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -263,7 +263,7 @@ setup(
     version="0.14.0",
 
     description='FFI bindings to libsecp256k1',
-    url='https://github.com/ludbb/secp256k1-py',
+    url='https://github.com/rustyrussell/secp256k1-py',
     author='Ludvig Broberg',
     author_email='lud@tutanota.com',
     maintainer='Rusty Russell',


### PR DESCRIPTION
Update the url in setup metadata to new repository. Hopefully, this will make sure people will report issues to the new repository instead of the old one.