### PR TITLE
isorted and blackified

### DIFF
--- a/_cffi_build/build.py
+++ b/_cffi_build/build.py
@@ -6,12 +6,10 @@ from itertools import combinations
 from cffi import FFI, VerificationError
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
-from setup_support import (has_system_lib,  # noqa: E402
-                           redirect,
-                           workdir,
-                           absolute)
+from setup_support import has_system_lib  # noqa: E402
+from setup_support import absolute, redirect, workdir
 
-Source = namedtuple('Source', ('h', 'include'))
+Source = namedtuple("Source", ("h", "include"))
 
 
 class Break(Exception):
@@ -21,12 +19,12 @@ class Break(Exception):
 def _mk_ffi(sources, name="_libsecp256k1", bundled=True, **kwargs):
     ffi = FFI()
     code = []
-    if 'INCLUDE_DIR' in os.environ:
-        kwargs['include_dirs'] = [absolute(os.environ['INCLUDE_DIR'])]
-    if 'LIB_DIR' in os.environ:
-        kwargs['library_dirs'] = [absolute(os.environ['LIB_DIR'])]
+    if "INCLUDE_DIR" in os.environ:
+        kwargs["include_dirs"] = [absolute(os.environ["INCLUDE_DIR"])]
+    if "LIB_DIR" in os.environ:
+        kwargs["library_dirs"] = [absolute(os.environ["LIB_DIR"])]
     for source in sources:
-        with open(source.h, 'rt') as h:
+        with open(source.h, "rt") as h:
             ffi.cdef(h.read())
         code.append(source.include)
     if bundled:
@@ -35,18 +33,30 @@ def _mk_ffi(sources, name="_libsecp256k1", bundled=True, **kwargs):
     return ffi
 
 
-_base = [Source(absolute("_cffi_build/secp256k1.h"),
-                "#include <secp256k1.h>", )]
+_base = [
+    Source(
+        absolute("_cffi_build/secp256k1.h"),
+        "#include <secp256k1.h>",
+    )
+]
 
 _modules = {
-    'ecdh': Source(absolute("_cffi_build/secp256k1_ecdh.h"),
-                   "#include <secp256k1_ecdh.h>", ),
-    'recovery': Source(absolute("_cffi_build/secp256k1_recovery.h"),
-                       "#include <secp256k1_recovery.h>", ),
-    'schnorrsig': Source(absolute("_cffi_build/secp256k1_schnorrsig.h"),
-                         "#include <secp256k1_schnorrsig.h>", ),
-    'extrakeys': Source(absolute("_cffi_build/secp256k1_extrakeys.h"),
-                        "#include <secp256k1_extrakeys.h>", ),
+    "ecdh": Source(
+        absolute("_cffi_build/secp256k1_ecdh.h"),
+        "#include <secp256k1_ecdh.h>",
+    ),
+    "recovery": Source(
+        absolute("_cffi_build/secp256k1_recovery.h"),
+        "#include <secp256k1_recovery.h>",
+    ),
+    "schnorrsig": Source(
+        absolute("_cffi_build/secp256k1_schnorrsig.h"),
+        "#include <secp256k1_schnorrsig.h>",
+    ),
+    "extrakeys": Source(
+        absolute("_cffi_build/secp256k1_extrakeys.h"),
+        "#include <secp256k1_extrakeys.h>",
+    ),
 }
 
 
@@ -67,7 +77,7 @@ if has_system_lib():
                         _base + [item[1] for item in combination],
                         name="_testcompile",
                         bundled=False,
-                        libraries=['secp256k1']
+                        libraries=["secp256k1"],
                     )
                     with redirect(sys.stderr, os.devnull), workdir():
                         _test_ffi.compile()
@@ -77,26 +87,25 @@ if has_system_lib():
                     pass
     except Break:
         ffi = _mk_ffi(
-            _base + [i[1] for i in _available],
-            bundled=False,
-            libraries=['secp256k1']
+            _base + [i[1] for i in _available], bundled=False, libraries=["secp256k1"]
         )
-        print("Using system libsecp256k1 with modules: {}".format(
-            ", ".join(i[0] for i in _available))
+        print(
+            "Using system libsecp256k1 with modules: {}".format(
+                ", ".join(i[0] for i in _available)
+            )
         )
     else:
         # We didn't find any functioning combination of modules
         # Normally this shouldn't happen but just in case we will fall back
         # to the bundled library
-        print("Installed libsecp256k1 is unusable"
-              " falling back to bundled version.")
+        print("Installed libsecp256k1 is unusable" " falling back to bundled version.")
 
 if ffi is None:
     # Library is not installed - use bundled one
     print("Using bundled libsecp256k1")
 
     # We usually build all the experimental bits, since they're useful.
-    if not os.environ.get('SECP_BUNDLED_NO_EXPERIMENTAL'):
-        ffi = _mk_ffi(_base + list(_modules.values()), libraries=['secp256k1'])
+    if not os.environ.get("SECP_BUNDLED_NO_EXPERIMENTAL"):
+        ffi = _mk_ffi(_base + list(_modules.values()), libraries=["secp256k1"])
     else:
-        ffi = _mk_ffi(_base + [_modules['recovery']], libraries=['secp256k1'])
+        ffi = _mk_ffi(_base + [_modules["recovery"]], libraries=["secp256k1"])

--- a/secp256k1/__init__.py
+++ b/secp256k1/__init__.py
@@ -1,50 +1,52 @@
-import os
-import hashlib
 import binascii
+import hashlib
+import os
 
 from ._libsecp256k1 import ffi, lib
-
 
 EC_COMPRESSED = lib.SECP256K1_EC_COMPRESSED
 EC_UNCOMPRESSED = lib.SECP256K1_EC_UNCOMPRESSED
 
-HAS_RECOVERABLE = hasattr(lib, 'secp256k1_ecdsa_sign_recoverable')
-HAS_SCHNORR = hasattr(lib, 'secp256k1_schnorrsig_sign')
-HAS_ECDH = hasattr(lib, 'secp256k1_ecdh')
-HAS_EXTRAKEYS = hasattr(lib, 'secp256k1_keypair_create')
+HAS_RECOVERABLE = hasattr(lib, "secp256k1_ecdsa_sign_recoverable")
+HAS_SCHNORR = hasattr(lib, "secp256k1_schnorrsig_sign")
+HAS_ECDH = hasattr(lib, "secp256k1_ecdh")
+HAS_EXTRAKEYS = hasattr(lib, "secp256k1_keypair_create")
 
 # Keeping a single one of these is most efficient.
-secp256k1_ctx = lib.secp256k1_context_create(lib.SECP256K1_CONTEXT_SIGN
-                                             | lib.SECP256K1_CONTEXT_VERIFY)
+secp256k1_ctx = lib.secp256k1_context_create(
+    lib.SECP256K1_CONTEXT_SIGN | lib.SECP256K1_CONTEXT_VERIFY
+)
 
 
 class ECDSA:
-
     def ecdsa_serialize(self, raw_sig):
         len_sig = 74
-        output = ffi.new('unsigned char[%d]' % len_sig)
-        outputlen = ffi.new('size_t *', len_sig)
+        output = ffi.new("unsigned char[%d]" % len_sig)
+        outputlen = ffi.new("size_t *", len_sig)
 
         res = lib.secp256k1_ecdsa_signature_serialize_der(
-            secp256k1_ctx, output, outputlen, raw_sig)
+            secp256k1_ctx, output, outputlen, raw_sig
+        )
         assert res == 1
 
         return bytes(ffi.buffer(output, outputlen[0]))
 
     def ecdsa_deserialize(self, ser_sig):
-        raw_sig = ffi.new('secp256k1_ecdsa_signature *')
+        raw_sig = ffi.new("secp256k1_ecdsa_signature *")
         res = lib.secp256k1_ecdsa_signature_parse_der(
-            secp256k1_ctx, raw_sig, ser_sig, len(ser_sig))
+            secp256k1_ctx, raw_sig, ser_sig, len(ser_sig)
+        )
         assert res == 1
 
         return raw_sig
 
     def ecdsa_serialize_compact(self, raw_sig):
         len_sig = 64
-        output = ffi.new('unsigned char[%d]' % len_sig)
+        output = ffi.new("unsigned char[%d]" % len_sig)
 
         res = lib.secp256k1_ecdsa_signature_serialize_compact(
-            secp256k1_ctx, output, raw_sig)
+            secp256k1_ctx, output, raw_sig
+        )
         assert res == 1
 
         return bytes(ffi.buffer(output, len_sig))
@@ -53,9 +55,10 @@ class ECDSA:
         if len(ser_sig) != 64:
             raise Exception("invalid signature length")
 
-        raw_sig = ffi.new('secp256k1_ecdsa_signature *')
+        raw_sig = ffi.new("secp256k1_ecdsa_signature *")
         res = lib.secp256k1_ecdsa_signature_parse_compact(
-            secp256k1_ctx, raw_sig, ser_sig)
+            secp256k1_ctx, raw_sig, ser_sig
+        )
         assert res == 1
 
         return raw_sig
@@ -73,37 +76,37 @@ class ECDSA:
         if check_only:
             sigout = ffi.NULL
         else:
-            sigout = ffi.new('secp256k1_ecdsa_signature *')
+            sigout = ffi.new("secp256k1_ecdsa_signature *")
 
-        result = lib.secp256k1_ecdsa_signature_normalize(
-            secp256k1_ctx, sigout, raw_sig)
+        result = lib.secp256k1_ecdsa_signature_normalize(secp256k1_ctx, sigout, raw_sig)
 
         return (bool(result), sigout if sigout != ffi.NULL else None)
 
-    def ecdsa_recover(self, msg, recover_sig, raw=False,
-                      digest=hashlib.sha256):
+    def ecdsa_recover(self, msg, recover_sig, raw=False, digest=hashlib.sha256):
         if not HAS_RECOVERABLE:
             raise Exception("secp256k1_recovery not enabled")
 
         msg32 = _hash32(msg, raw, digest)
-        pubkey = ffi.new('secp256k1_pubkey *')
+        pubkey = ffi.new("secp256k1_pubkey *")
 
         recovered = lib.secp256k1_ecdsa_recover(
-            secp256k1_ctx, pubkey, recover_sig, msg32)
+            secp256k1_ctx, pubkey, recover_sig, msg32
+        )
         if recovered:
             return pubkey
-        raise Exception('failed to recover ECDSA public key')
+        raise Exception("failed to recover ECDSA public key")
 
     def ecdsa_recoverable_serialize(self, recover_sig):
         if not HAS_RECOVERABLE:
             raise Exception("secp256k1_recovery not enabled")
 
         outputlen = 64
-        output = ffi.new('unsigned char[%d]' % outputlen)
-        recid = ffi.new('int *')
+        output = ffi.new("unsigned char[%d]" % outputlen)
+        recid = ffi.new("int *")
 
         lib.secp256k1_ecdsa_recoverable_signature_serialize_compact(
-            secp256k1_ctx, output, recid, recover_sig)
+            secp256k1_ctx, output, recid, recover_sig
+        )
 
         return bytes(ffi.buffer(output, outputlen)), recid[0]
 
@@ -115,39 +118,40 @@ class ECDSA:
         if len(ser_sig) != 64:
             raise Exception("invalid signature length")
 
-        recover_sig = ffi.new('secp256k1_ecdsa_recoverable_signature *')
+        recover_sig = ffi.new("secp256k1_ecdsa_recoverable_signature *")
 
         parsed = lib.secp256k1_ecdsa_recoverable_signature_parse_compact(
-            secp256k1_ctx, recover_sig, ser_sig, rec_id)
+            secp256k1_ctx, recover_sig, ser_sig, rec_id
+        )
         if parsed:
             return recover_sig
         else:
-            raise Exception('failed to parse ECDSA compact sig')
+            raise Exception("failed to parse ECDSA compact sig")
 
     def ecdsa_recoverable_convert(self, recover_sig):
         if not HAS_RECOVERABLE:
             raise Exception("secp256k1_recovery not enabled")
 
-        normal_sig = ffi.new('secp256k1_ecdsa_signature *')
+        normal_sig = ffi.new("secp256k1_ecdsa_signature *")
 
         lib.secp256k1_ecdsa_recoverable_signature_convert(
-            secp256k1_ctx, normal_sig, recover_sig)
+            secp256k1_ctx, normal_sig, recover_sig
+        )
 
         return normal_sig
 
 
 class PublicKey(ECDSA):
-
     def __init__(self, pubkey=None, raw=False):
         if pubkey is not None:
             if raw:
                 if not isinstance(pubkey, bytes):
-                    raise TypeError('raw pubkey must be bytes')
+                    raise TypeError("raw pubkey must be bytes")
                 self.public_key = self.deserialize(pubkey)
             else:
                 if not isinstance(pubkey, ffi.CData):
-                    raise TypeError('pubkey must be an internal object')
-                assert ffi.typeof(pubkey) is ffi.typeof('secp256k1_pubkey *')
+                    raise TypeError("pubkey must be an internal object")
+                assert ffi.typeof(pubkey) is ffi.typeof("secp256k1_pubkey *")
                 self.public_key = pubkey
             self._pubkey_changed()
         else:
@@ -155,22 +159,25 @@ class PublicKey(ECDSA):
 
     def _pubkey_changed(self):
         if HAS_EXTRAKEYS:
-            self.xonly_pubkey = ffi.new('secp256k1_xonly_pubkey *')
-            assert lib.secp256k1_xonly_pubkey_from_pubkey(secp256k1_ctx,
-                                                          self.xonly_pubkey,
-                                                          ffi.NULL,
-                                                          self.public_key) == 1
+            self.xonly_pubkey = ffi.new("secp256k1_xonly_pubkey *")
+            assert (
+                lib.secp256k1_xonly_pubkey_from_pubkey(
+                    secp256k1_ctx, self.xonly_pubkey, ffi.NULL, self.public_key
+                )
+                == 1
+            )
 
     def serialize(self, compressed=True):
         assert self.public_key, "No public key defined"
 
         len_compressed = 33 if compressed else 65
-        res_compressed = ffi.new('char [%d]' % len_compressed)
-        outlen = ffi.new('size_t *', len_compressed)
+        res_compressed = ffi.new("char [%d]" % len_compressed)
+        outlen = ffi.new("size_t *", len_compressed)
         compflag = EC_COMPRESSED if compressed else EC_UNCOMPRESSED
 
         serialized = lib.secp256k1_ec_pubkey_serialize(
-            secp256k1_ctx, res_compressed, outlen, self.public_key, compflag)
+            secp256k1_ctx, res_compressed, outlen, self.public_key, compflag
+        )
         assert serialized == 1
 
         return bytes(ffi.buffer(res_compressed, len_compressed))
@@ -179,10 +186,11 @@ class PublicKey(ECDSA):
         if len(pubkey_ser) not in (33, 65):
             raise Exception("unknown public key size (expected 33 or 65)")
 
-        pubkey = ffi.new('secp256k1_pubkey *')
+        pubkey = ffi.new("secp256k1_pubkey *")
 
         res = lib.secp256k1_ec_pubkey_parse(
-            secp256k1_ctx, pubkey, pubkey_ser, len(pubkey_ser))
+            secp256k1_ctx, pubkey, pubkey_ser, len(pubkey_ser)
+        )
         if not res:
             raise Exception("invalid public key")
 
@@ -194,14 +202,15 @@ class PublicKey(ECDSA):
         """Add a number of public keys together."""
         assert len(pubkeys) > 0
 
-        outpub = ffi.new('secp256k1_pubkey *')
+        outpub = ffi.new("secp256k1_pubkey *")
         for item in pubkeys:
-            assert ffi.typeof(item) is ffi.typeof('secp256k1_pubkey *')
+            assert ffi.typeof(item) is ffi.typeof("secp256k1_pubkey *")
 
         res = lib.secp256k1_ec_pubkey_combine(
-            secp256k1_ctx, outpub, pubkeys, len(pubkeys))
+            secp256k1_ctx, outpub, pubkeys, len(pubkeys)
+        )
         if not res:
-            raise Exception('failed to combine public keys')
+            raise Exception("failed to combine public keys")
 
         self.public_key = outpub
         self._pubkey_changed()
@@ -227,7 +236,8 @@ class PublicKey(ECDSA):
         msg32 = _hash32(msg, raw, digest)
 
         verified = lib.secp256k1_ecdsa_verify(
-            secp256k1_ctx, raw_sig, msg32, self.public_key)
+            secp256k1_ctx, raw_sig, msg32, self.public_key
+        )
 
         return bool(verified)
 
@@ -239,8 +249,8 @@ class PublicKey(ECDSA):
         msg_to_sign = _bip340_tag(msg, raw, bip340tag)
 
         verified = lib.secp256k1_schnorrsig_verify(
-            secp256k1_ctx, schnorr_sig, msg_to_sign, len(msg_to_sign),
-            self.xonly_pubkey)
+            secp256k1_ctx, schnorr_sig, msg_to_sign, len(msg_to_sign), self.xonly_pubkey
+        )
 
         return bool(verified)
 
@@ -250,20 +260,20 @@ class PublicKey(ECDSA):
             raise Exception("secp256k1_ecdh not enabled")
         # Technically, it need only match the hashfn, but this is standard.
         if not isinstance(scalar, bytes) or len(scalar) != 32:
-            raise TypeError('scalar must be composed of 32 bytes')
+            raise TypeError("scalar must be composed of 32 bytes")
 
-        result = ffi.new('char [32]')
+        result = ffi.new("char [32]")
 
-        res = lib.secp256k1_ecdh(secp256k1_ctx, result, self.public_key,
-                                 scalar, hashfn, hasharg)
+        res = lib.secp256k1_ecdh(
+            secp256k1_ctx, result, self.public_key, scalar, hashfn, hasharg
+        )
         if not res:
-            raise Exception('invalid scalar ({})'.format(res))
+            raise Exception("invalid scalar ({})".format(res))
 
         return bytes(ffi.buffer(result, 32))
 
 
 class PrivateKey(ECDSA):
-
     def __init__(self, privkey=None, raw=True):
         self.pubkey = None
         self.private_key = None
@@ -272,7 +282,7 @@ class PrivateKey(ECDSA):
         else:
             if raw:
                 if not isinstance(privkey, bytes) or len(privkey) != 32:
-                    raise TypeError('privkey must be composed of 32 bytes')
+                    raise TypeError("privkey must be composed of 32 bytes")
                 self.set_raw_privkey(privkey)
             else:
                 self.deserialize(privkey)
@@ -281,10 +291,13 @@ class PrivateKey(ECDSA):
         public_key = self._gen_public_key(self.private_key)
         self.pubkey = PublicKey(public_key, raw=False)
         if HAS_EXTRAKEYS:
-            self.keypair = ffi.new('secp256k1_keypair *')
-            if lib.secp256k1_keypair_create(secp256k1_ctx,
-                                            self.keypair,
-                                            self.private_key) != 1:
+            self.keypair = ffi.new("secp256k1_keypair *")
+            if (
+                lib.secp256k1_keypair_create(
+                    secp256k1_ctx, self.keypair, self.private_key
+                )
+                != 1
+            ):
                 raise Exception("invalid private key (can't make keypair?)")
 
     def set_raw_privkey(self, privkey):
@@ -295,7 +308,7 @@ class PrivateKey(ECDSA):
 
     def serialize(self):
         hexkey = binascii.hexlify(self.private_key)
-        return hexkey.decode('utf8')
+        return hexkey.decode("utf8")
 
     def deserialize(self, privkey_ser):
         if len(privkey_ser) != 64:
@@ -306,10 +319,9 @@ class PrivateKey(ECDSA):
         return self.private_key
 
     def _gen_public_key(self, privkey):
-        pubkey_ptr = ffi.new('secp256k1_pubkey *')
+        pubkey_ptr = ffi.new("secp256k1_pubkey *")
 
-        created = lib.secp256k1_ec_pubkey_create(secp256k1_ctx,
-                                                 pubkey_ptr, privkey)
+        created = lib.secp256k1_ec_pubkey_create(secp256k1_ctx, pubkey_ptr, privkey)
         assert created == 1
 
         return pubkey_ptr
@@ -328,17 +340,16 @@ class PrivateKey(ECDSA):
         """
         return _tweak_private(self, lib.secp256k1_ec_privkey_tweak_mul, scalar)
 
-    def ecdsa_sign(self, msg, raw=False, digest=hashlib.sha256,
-                   custom_nonce=None):
+    def ecdsa_sign(self, msg, raw=False, digest=hashlib.sha256, custom_nonce=None):
         msg32 = _hash32(msg, raw, digest)
-        raw_sig = ffi.new('secp256k1_ecdsa_signature *')
+        raw_sig = ffi.new("secp256k1_ecdsa_signature *")
         nonce_fn = ffi.NULL
         nonce_data = ffi.NULL
         if custom_nonce:
             nonce_fn, nonce_data = custom_nonce
         signed = lib.secp256k1_ecdsa_sign(
-            secp256k1_ctx, raw_sig, msg32, self.private_key,
-            nonce_fn, nonce_data)
+            secp256k1_ctx, raw_sig, msg32, self.private_key, nonce_fn, nonce_data
+        )
         assert signed == 1
 
         return raw_sig
@@ -348,11 +359,11 @@ class PrivateKey(ECDSA):
             raise Exception("secp256k1_recovery not enabled")
 
         msg32 = _hash32(msg, raw, digest)
-        raw_sig = ffi.new('secp256k1_ecdsa_recoverable_signature *')
+        raw_sig = ffi.new("secp256k1_ecdsa_recoverable_signature *")
 
         signed = lib.secp256k1_ecdsa_sign_recoverable(
-            secp256k1_ctx, raw_sig, msg32, self.private_key,
-            ffi.NULL, ffi.NULL)
+            secp256k1_ctx, raw_sig, msg32, self.private_key, ffi.NULL, ffi.NULL
+        )
         assert signed == 1
 
         return raw_sig
@@ -362,12 +373,12 @@ class PrivateKey(ECDSA):
             raise Exception("secp256k1_schnorr not enabled")
 
         msg_to_sign = _bip340_tag(msg, raw, bip340tag)
-        sig64 = ffi.new('char [64]')
+        sig64 = ffi.new("char [64]")
 
         # FIXME: It's recommended to provide aux_rand32...
         signed = lib.secp256k1_schnorrsig_sign_custom(
-            secp256k1_ctx, sig64, msg_to_sign, len(msg_to_sign),
-            self.keypair, ffi.NULL)
+            secp256k1_ctx, sig64, msg_to_sign, len(msg_to_sign), self.keypair, ffi.NULL
+        )
         assert signed == 1
 
         return bytes(ffi.buffer(sig64, 64))
@@ -382,9 +393,10 @@ def _bip340_tag(msg, raw, tag):
     else:
         bytestag = tag.encode()
 
-    hash32 = ffi.new('char [32]')
-    lib.secp256k1_tagged_sha256(secp256k1_ctx, hash32, bytestag, len(bytestag),
-                                msg, len(msg))
+    hash32 = ffi.new("char [32]")
+    lib.secp256k1_tagged_sha256(
+        secp256k1_ctx, hash32, bytestag, len(bytestag), msg, len(msg)
+    )
     return bytes(ffi.buffer(hash32, 32))
 
 
@@ -405,7 +417,7 @@ def _gen_private_key():
 
 def _tweak_public(inst, func, scalar):
     if not isinstance(scalar, bytes) or len(scalar) != 32:
-        raise TypeError('scalar must be composed of 32 bytes')
+        raise TypeError("scalar must be composed of 32 bytes")
     assert inst.public_key, "No public key defined."
 
     # Create a copy of the current public key.
@@ -420,10 +432,10 @@ def _tweak_public(inst, func, scalar):
 
 def _tweak_private(inst, func, scalar):
     if not isinstance(scalar, bytes) or len(scalar) != 32:
-        raise TypeError('scalar must be composed of 32 bytes')
+        raise TypeError("scalar must be composed of 32 bytes")
 
     # Create a copy of the current private key.
-    key = ffi.new('char [32]', inst.private_key)
+    key = ffi.new("char [32]", inst.private_key)
 
     res = func(secp256k1_ctx, key, scalar)
     if not res:
@@ -433,13 +445,12 @@ def _tweak_private(inst, func, scalar):
 
 
 # Apparently flake8 thinks this is "too complex".  Maybe FIXME?
-def _main_cli(args, out, encoding='utf-8'):  # noqa: C901
+def _main_cli(args, out, encoding="utf-8"):  # noqa: C901
     import binascii
 
     def show_public(public_key):
         rawp = public_key.serialize()
-        out.write(u"Public key: {}\n".format(
-            binascii.hexlify(rawp).decode(encoding)))
+        out.write("Public key: {}\n".format(binascii.hexlify(rawp).decode(encoding)))
 
     def sign(funcname, params):
         raw = bytes(bytearray.fromhex(params.private_key))
@@ -448,25 +459,25 @@ def _main_cli(args, out, encoding='utf-8'):  # noqa: C901
         sig = func(params.message)
         return priv, sig
 
-    if args.action == 'privkey':
+    if args.action == "privkey":
         if args.private_key:
             rawkey = bytes(bytearray.fromhex(args.private_key))
         else:
             rawkey = None
         priv = PrivateKey(rawkey)
         raw = priv.private_key
-        out.write(u"{}\n".format(binascii.hexlify(raw).decode(encoding)))
+        out.write("{}\n".format(binascii.hexlify(raw).decode(encoding)))
         if args.show_pubkey:
             show_public(priv.pubkey)
 
-    elif args.action == 'sign':
-        priv, sig_raw = sign('ecdsa_sign', args)
+    elif args.action == "sign":
+        priv, sig_raw = sign("ecdsa_sign", args)
         sig = priv.ecdsa_serialize(sig_raw)
-        out.write(u"{}\n".format(binascii.hexlify(sig).decode(encoding)))
+        out.write("{}\n".format(binascii.hexlify(sig).decode(encoding)))
         if args.show_pubkey:
             show_public(priv.pubkey)
 
-    elif args.action == 'checksig':
+    elif args.action == "checksig":
         raw = bytes(bytearray.fromhex(args.public_key))
         sig = bytes(bytearray.fromhex(args.signature))
         pub = PublicKey(raw, raw=True)
@@ -475,18 +486,17 @@ def _main_cli(args, out, encoding='utf-8'):  # noqa: C901
             good = pub.ecdsa_verify(args.message, sig_raw)
         except:  # noqa: E722
             good = False
-        out.write(u"{}\n".format(good))
+        out.write("{}\n".format(good))
         return 0 if good else 1
 
-    elif args.action == 'signrec':
-        priv, sig = sign('ecdsa_sign_recoverable', args)
+    elif args.action == "signrec":
+        priv, sig = sign("ecdsa_sign_recoverable", args)
         sig, recid = priv.ecdsa_recoverable_serialize(sig)
-        out.write(u"{} {}\n".format(binascii.hexlify(sig).decode(encoding),
-                                    recid))
+        out.write("{} {}\n".format(binascii.hexlify(sig).decode(encoding), recid))
         if args.show_pubkey:
             show_public(priv.pubkey)
 
-    elif args.action == 'recpub':
+    elif args.action == "recpub":
         empty = PublicKey()
         sig_raw = bytes(bytearray.fromhex(args.signature))
         sig = empty.ecdsa_recoverable_deserialize(sig_raw, args.recid)
@@ -507,41 +517,42 @@ def _parse_cli():
         return s if py2 else s.encode(enc)
 
     parser = ArgumentParser(prog="secp256k1")
-    subparser = parser.add_subparsers(dest='action')
+    subparser = parser.add_subparsers(dest="action")
 
-    genparser = subparser.add_parser('privkey')
-    genparser.add_argument('-p', '--show-pubkey', action='store_true')
-    genparser.add_argument('-k', '--private_key')
+    genparser = subparser.add_parser("privkey")
+    genparser.add_argument("-p", "--show-pubkey", action="store_true")
+    genparser.add_argument("-k", "--private_key")
 
-    sign = subparser.add_parser('sign')
-    sign.add_argument('-k', '--private-key', required=True)
-    sign.add_argument('-m', '--message', required=True, type=bytes_input)
-    sign.add_argument('-p', '--show-pubkey', action='store_true')
+    sign = subparser.add_parser("sign")
+    sign.add_argument("-k", "--private-key", required=True)
+    sign.add_argument("-m", "--message", required=True, type=bytes_input)
+    sign.add_argument("-p", "--show-pubkey", action="store_true")
 
-    signrec = subparser.add_parser('signrec')
-    signrec.add_argument('-k', '--private-key', required=True)
-    signrec.add_argument('-m', '--message', required=True, type=bytes_input)
-    signrec.add_argument('-p', '--show-pubkey', action='store_true')
+    signrec = subparser.add_parser("signrec")
+    signrec.add_argument("-k", "--private-key", required=True)
+    signrec.add_argument("-m", "--message", required=True, type=bytes_input)
+    signrec.add_argument("-p", "--show-pubkey", action="store_true")
 
-    check = subparser.add_parser('checksig')
-    check.add_argument('-p', '--public-key', required=True)
-    check.add_argument('-m', '--message', required=True, type=bytes_input)
-    check.add_argument('-s', '--signature', required=True)
+    check = subparser.add_parser("checksig")
+    check.add_argument("-p", "--public-key", required=True)
+    check.add_argument("-m", "--message", required=True, type=bytes_input)
+    check.add_argument("-s", "--signature", required=True)
 
-    recpub = subparser.add_parser('recpub')
-    recpub.add_argument('-m', '--message', required=True, type=bytes_input)
-    recpub.add_argument('-i', '--recid', required=True, type=int)
-    recpub.add_argument('-s', '--signature', required=True)
+    recpub = subparser.add_parser("recpub")
+    recpub.add_argument("-m", "--message", required=True, type=bytes_input)
+    recpub.add_argument("-i", "--recid", required=True, type=int)
+    recpub.add_argument("-s", "--signature", required=True)
 
     return parser, enc
 
 
 def main():
     import sys
+
     parser, enc = _parse_cli()
     args = parser.parse_args(sys.argv[1:])
     sys.exit(_main_cli(args, sys.stdout, enc))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/secp256k1/__main__.py
+++ b/secp256k1/__main__.py
@@ -2,6 +2,5 @@ from __future__ import absolute_import
 
 from . import main
 
-
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import os
 import os.path
 import shutil
 import subprocess
+import sys
 import tarfile
 import tempfile
 from distutils import log
@@ -11,50 +12,50 @@ from distutils.command.build_clib import build_clib as _build_clib
 from distutils.command.build_ext import build_ext as _build_ext
 from distutils.errors import DistutilsError
 from io import BytesIO
-import sys
 
-from setuptools import (Distribution as _Distribution,
-                        setup,
-                        find_packages,
-                        __version__ as setuptools_version)
+from setuptools import Distribution as _Distribution
+from setuptools import __version__ as setuptools_version
+from setuptools import find_packages, setup
 from setuptools.command.develop import develop as _develop
 from setuptools.command.egg_info import egg_info as _egg_info
 from setuptools.command.sdist import sdist as _sdist
+
 try:
     from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 except ImportError:
     _bdist_wheel = None
-    pass
 
 try:
-    from urllib2 import urlopen, URLError
+    from urllib2 import URLError, urlopen
 except ImportError:
-    from urllib.request import urlopen
     from urllib.error import URLError
+    from urllib.request import urlopen
 
 
 sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from setup_support import absolute, build_flags, has_system_lib  # noqa: E402
 
-
 # Version of libsecp256k1 to download if none exists in the `libsecp256k1`
 # directory
-LIB_TARBALL_URL = ("https://github.com/bitcoin-core/secp256k1/archive/"
-                   "9526874d1406a13193743c605ba64358d55a8785"
-                   ".tar.gz")
+LIB_TARBALL_URL = (
+    "https://github.com/bitcoin-core/secp256k1/archive/"
+    "9526874d1406a13193743c605ba64358d55a8785"
+    ".tar.gz"
+)
 
 
 # We require setuptools >= 3.3
-if [int(i) for i in setuptools_version.split('.')] < [3, 3]:
+if [int(i) for i in setuptools_version.split(".")] < [3, 3]:
     raise SystemExit(
         "Your setuptools version ({}) is too old to correctly install this "
-        "package. Please upgrade to a newer version (>= 3.3)."
-        .format(setuptools_version)
+        "package. Please upgrade to a newer version (>= 3.3).".format(
+            setuptools_version
+        )
     )
 
 # Ensure pkg-config is available
 try:
-    subprocess.check_call(['pkg-config', '--version'])
+    subprocess.check_call(["pkg-config", "--version"])
 except OSError:
     raise SystemExit(
         "'pkg-config' is required to install this package. "
@@ -70,25 +71,22 @@ def download_library(command):
         # Library already downloaded
         return
     if not os.path.exists(libdir):
-        command.announce("downloading libsecp256k1 source code",
-                         level=log.INFO)
+        command.announce("downloading libsecp256k1 source code", level=log.INFO)
         try:
             r = urlopen(LIB_TARBALL_URL)
             if r.getcode() == 200:
                 content = BytesIO(r.read())
                 content.seek(0)
                 with tarfile.open(fileobj=content) as tf:
-                    dirname = tf.getnames()[0].partition('/')[0]
+                    dirname = tf.getnames()[0].partition("/")[0]
                     tf.extractall()
                 shutil.move(dirname, libdir)
             else:
                 raise SystemExit(
-                    "Unable to download secp256k1 library: HTTP-Status: %d",
-                    r.getcode()
+                    "Unable to download secp256k1 library: HTTP-Status: %d", r.getcode()
                 )
         except URLError as ex:
-            raise SystemExit("Unable to download secp256k1 library: %s",
-                             ex.message)
+            raise SystemExit("Unable to download secp256k1 library: %s", ex.message)
 
 
 class egg_info(_egg_info):
@@ -106,10 +104,12 @@ class sdist(_sdist):
 
 
 if _bdist_wheel:
+
     class bdist_wheel(_bdist_wheel):
         def run(self):
             download_library(self)
             _bdist_wheel.run(self)
+
 else:
     bdist_wheel = None
 
@@ -128,9 +128,9 @@ class build_clib(_build_clib):
         _build_clib.finalize_options(self)
         if self.build_flags is None:
             self.build_flags = {
-                'include_dirs': [],
-                'library_dirs': [],
-                'define': [],
+                "include_dirs": [],
+                "library_dirs": [],
+                "define": [],
             }
 
     def get_source_files(self):
@@ -150,8 +150,7 @@ class build_clib(_build_clib):
         raise Exception("check_library_list")
 
     def get_library_names(self):
-        return build_flags('libsecp256k1', 'l',
-                           os.path.abspath(self.build_clib))
+        return build_flags("libsecp256k1", "l", os.path.abspath(self.build_clib))
 
     def run(self):
         if has_system_lib():
@@ -202,14 +201,16 @@ class build_clib(_build_clib):
             os.path.abspath(self.build_clib),
         ]
 
-        if not os.environ.get('SECP_BUNDLED_NO_EXPERIMENTAL'):
+        if not os.environ.get("SECP_BUNDLED_NO_EXPERIMENTAL"):
             log.info("Building experimental")
-            cmd.extend([
-                "--enable-experimental",
-                "--enable-module-ecdh",
-                "--enable-module-schnorrsig",
-                "--enable-module-extrakeys",
-            ])
+            cmd.extend(
+                [
+                    "--enable-experimental",
+                    "--enable-module-ecdh",
+                    "--enable-module-schnorrsig",
+                    "--enable-module-extrakeys",
+                ]
+            )
 
         with tempfile.TemporaryDirectory() as build_temp:
             log.debug("Running configure: {}".format(" ".join(cmd)))
@@ -221,14 +222,14 @@ class build_clib(_build_clib):
             subprocess.check_call(["make"], cwd=build_temp)
             subprocess.check_call(["make", "install"], cwd=build_temp)
 
-        self.build_flags['include_dirs'].extend(build_flags('libsecp256k1',
-                                                            'I',
-                                                            self.build_clib))
-        self.build_flags['library_dirs'].extend(build_flags('libsecp256k1',
-                                                            'L',
-                                                            self.build_clib))
+        self.build_flags["include_dirs"].extend(
+            build_flags("libsecp256k1", "I", self.build_clib)
+        )
+        self.build_flags["library_dirs"].extend(
+            build_flags("libsecp256k1", "L", self.build_clib)
+        )
         if not has_system_lib():
-            self.build_flags['define'].append(('CFFI_ENABLE_RECOVERY', None))
+            self.build_flags["define"].append(("CFFI_ENABLE_RECOVERY", None))
         else:
             pass
 
@@ -240,14 +241,14 @@ class build_ext(_build_ext):
             self.include_dirs.append(
                 os.path.join(build_clib.build_clib, "include"),
             )
-            self.include_dirs.extend(build_clib.build_flags['include_dirs'])
+            self.include_dirs.extend(build_clib.build_flags["include_dirs"])
 
             self.library_dirs.append(
                 os.path.join(build_clib.build_clib, "lib"),
             )
-            self.library_dirs.extend(build_clib.build_flags['library_dirs'])
+            self.library_dirs.extend(build_clib.build_flags["library_dirs"])
 
-            self.define = build_clib.build_flags['define']
+            self.define = build_clib.build_flags["define"]
 
         return _build_ext.run(self)
 
@@ -257,50 +258,42 @@ class develop(_develop):
         if not has_system_lib():
             raise DistutilsError(
                 "This library is not usable in 'develop' mode when using the "
-                "bundled libsecp256k1. See README for details.")
+                "bundled libsecp256k1. See README for details."
+            )
         _develop.run(self)
 
 
-with io.open('README.md', encoding='utf-8') as f:
+with io.open("README.md", encoding="utf-8") as f:
     long_description = f.read()
 
 setup(
     name="secp256k1",
     version="0.14.0",
-
-    description='FFI bindings to libsecp256k1',
+    description="FFI bindings to libsecp256k1",
     long_description=long_description,
-    long_description_content_type='text/markdown',
-    url='https://github.com/rustyrussell/secp256k1-py',
-    author='Ludvig Broberg',
-    author_email='lud@tutanota.com',
-    maintainer='Rusty Russell',
-    maintainer_email='rusty@rustcorp.com.au',
-    license='MIT',
-
-    setup_requires=['cffi>=1.3.0', 'pytest-runner==2.6.2'],
-    install_requires=['cffi>=1.3.0'],
-    tests_require=['pytest==2.8.7'],
-
-    packages=find_packages(exclude=('_cffi_build',
-                                    '_cffi_build.*',
-                                    'libsecp256k1')),
+    long_description_content_type="text/markdown",
+    url="https://github.com/rustyrussell/secp256k1-py",
+    author="Ludvig Broberg",
+    author_email="lud@tutanota.com",
+    maintainer="Rusty Russell",
+    maintainer_email="rusty@rustcorp.com.au",
+    license="MIT",
+    setup_requires=["cffi>=1.3.0", "pytest-runner==2.6.2"],
+    install_requires=["cffi>=1.3.0"],
+    tests_require=["pytest==2.8.7"],
+    packages=find_packages(exclude=("_cffi_build", "_cffi_build.*", "libsecp256k1")),
     ext_package="secp256k1",
-    cffi_modules=[
-        "_cffi_build/build.py:ffi"
-    ],
-
+    cffi_modules=["_cffi_build/build.py:ffi"],
     cmdclass={
-        'build_clib': build_clib,
-        'build_ext': build_ext,
-        'develop': develop,
-        'egg_info': egg_info,
-        'sdist': sdist,
-        'bdist_wheel': bdist_wheel
+        "build_clib": build_clib,
+        "build_ext": build_ext,
+        "develop": develop,
+        "egg_info": egg_info,
+        "sdist": sdist,
+        "bdist_wheel": bdist_wheel,
     },
     distclass=Distribution,
     zip_safe=False,
-
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",
@@ -309,6 +302,6 @@ setup(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries",
-        "Topic :: Security :: Cryptography"
-    ]
+        "Topic :: Security :: Cryptography",
+    ],
 )

--- a/setup_support.py
+++ b/setup_support.py
@@ -1,10 +1,9 @@
 import glob
 import os
 import shutil
+import subprocess
 from contextlib import contextmanager
 from tempfile import mkdtemp
-
-import subprocess
 
 
 @contextmanager
@@ -22,7 +21,7 @@ def workdir():
 @contextmanager
 def redirect(stdchannel, dest_filename):
     oldstdchannel = os.dup(stdchannel.fileno())
-    dest_file = open(dest_filename, 'w')
+    dest_file = open(dest_filename, "w")
     os.dup2(dest_file.fileno(), stdchannel.fileno())
     try:
         yield
@@ -41,42 +40,38 @@ def absolute(*paths):
 def build_flags(library, type_, path):
     """Return separated build flags from pkg-config output"""
 
-    pkg_config_path = [os.path.join(path, 'lib', 'pkgconfig')]
+    pkg_config_path = [os.path.join(path, "lib", "pkgconfig")]
     if "PKG_CONFIG_PATH" in os.environ:
-        pkg_config_path.append(os.environ['PKG_CONFIG_PATH'])
+        pkg_config_path.append(os.environ["PKG_CONFIG_PATH"])
     if "LIB_DIR" in os.environ:
-        pkg_config_path.append(os.environ['LIB_DIR'])
-        pkg_config_path.append(os.path.join(os.environ['LIB_DIR'],
-                                            "pkgconfig"))
+        pkg_config_path.append(os.environ["LIB_DIR"])
+        pkg_config_path.append(os.path.join(os.environ["LIB_DIR"], "pkgconfig"))
 
     options = [
         "--static",
-        {
-            'I': "--cflags-only-I",
-            'L': "--libs-only-L",
-            'l': "--libs-only-l"
-        }[type_]
+        {"I": "--cflags-only-I", "L": "--libs-only-L", "l": "--libs-only-l"}[type_],
     ]
 
     return [
         flag.strip("-{}".format(type_))
-        for flag
-        in subprocess.check_output(
+        for flag in subprocess.check_output(
             ["pkg-config"] + options + [library],
-            env=dict(os.environ, PKG_CONFIG_PATH=":".join(pkg_config_path))
-        ).decode("UTF-8").split()
+            env=dict(os.environ, PKG_CONFIG_PATH=":".join(pkg_config_path)),
+        )
+        .decode("UTF-8")
+        .split()
     ]
 
 
 def _find_lib():
     from cffi import FFI
+
     ffi = FFI()
     try:
         ffi.dlopen("secp256k1")
     except OSError:
-        if 'LIB_DIR' in os.environ:
-            for path in glob.glob(os.path.join(os.environ['LIB_DIR'],
-                                               "*secp256k1*")):
+        if "LIB_DIR" in os.environ:
+            for path in glob.glob(os.path.join(os.environ["LIB_DIR"], "*secp256k1*")):
                 try:
                     FFI().dlopen(path)
                     return True

--- a/tests/test_custom_nonce.py
+++ b/tests/test_custom_nonce.py
@@ -1,18 +1,21 @@
-import os
 import json
-import secp256k1
+import os
 import sys
 import tempfile
 
+import secp256k1
+
 HERE = os.path.dirname(os.path.abspath(__file__))
-DATA = os.path.join(HERE, 'data')
+DATA = os.path.join(HERE, "data")
 
 from cffi import FFI  # noqa: E402
 
 ffi = FFI()
-ffi.cdef('static int nonce_function_rand(unsigned char *nonce32,'
-         'const unsigned char *msg32,const unsigned char *key32,'
-         'const unsigned char *algo16,void *data,unsigned int attempt);')
+ffi.cdef(
+    "static int nonce_function_rand(unsigned char *nonce32,"
+    "const unsigned char *msg32,const unsigned char *key32,"
+    "const unsigned char *algo16,void *data,unsigned int attempt);"
+)
 
 # The most elementary conceivable nonce function, acting
 # as a passthrough: user provides random data which must be
@@ -24,8 +27,9 @@ ffi.cdef('static int nonce_function_rand(unsigned char *nonce32,'
 # Of course the likelihood of such an error is infinitesimal.
 # TLDR this is not intended to be used in real life; use
 # deterministic signatures.
-ffi.set_source("_noncefunc",
-               """
+ffi.set_source(
+    "_noncefunc",
+    """
 static int nonce_function_rand(unsigned char *nonce32,
 const unsigned char *msg32,
 const unsigned char *key32,
@@ -36,7 +40,8 @@ unsigned int attempt)
 memcpy(nonce32,data,32);
 return 1;
 }
-               """)
+               """,
+)
 
 with tempfile.TemporaryDirectory() as build_temp:
     ffi.compile(tmpdir=build_temp)
@@ -49,20 +54,19 @@ with tempfile.TemporaryDirectory() as build_temp:
 
 
 def test_ecdsa_with_custom_nonce():
-    data = open(os.path.join(DATA, 'ecdsa_custom_nonce_sig.json')).read()
-    vec = json.loads(data)['vectors']
+    data = open(os.path.join(DATA, "ecdsa_custom_nonce_sig.json")).read()
+    vec = json.loads(data)["vectors"]
     inst = secp256k1.PrivateKey()
     for item in vec:
-        seckey = bytes(bytearray.fromhex(item['privkey']))
-        msg32 = bytes(bytearray.fromhex(item['msg']))
-        sig = bytes(bytearray.fromhex(item['sig']))
-        randnonce = bytes(bytearray.fromhex(item['nonce']))
+        seckey = bytes(bytearray.fromhex(item["privkey"]))
+        msg32 = bytes(bytearray.fromhex(item["msg"]))
+        sig = bytes(bytearray.fromhex(item["sig"]))
+        randnonce = bytes(bytearray.fromhex(item["nonce"]))
         inst.set_raw_privkey(seckey)
         nf = ffi.addressof(_noncefunc.lib, "nonce_function_rand")
         ndata = ffi.new("char [32]", randnonce)
         sig_raw = inst.ecdsa_sign(msg32, raw=True, custom_nonce=(nf, ndata))
         sig_check = inst.ecdsa_serialize(sig_raw)
         assert sig_check == sig
-        assert (inst.ecdsa_serialize(inst.ecdsa_deserialize(sig_check))
-                == sig_check)
+        assert inst.ecdsa_serialize(inst.ecdsa_deserialize(sig_check)) == sig_check
         assert inst.pubkey.ecdsa_verify(msg32, sig_raw, raw=True)

--- a/tests/test_ecdh.py
+++ b/tests/test_ecdh.py
@@ -5,7 +5,7 @@ import secp256k1
 
 def test_ecdh():
     if not secp256k1.HAS_ECDH:
-        pytest.skip('secp256k1_ecdh not enabled, skipping')
+        pytest.skip("secp256k1_ecdh not enabled, skipping")
         return
 
     pubkey = secp256k1.PrivateKey().pubkey
@@ -13,10 +13,10 @@ def test_ecdh():
     p = secp256k1.PublicKey(pubkey.public_key)
     with pytest.raises(Exception):
         # Bad scalar length.
-        p.ecdh(b'')
+        p.ecdh(b"")
     with pytest.raises(Exception):
         # Bad scalar type.
         p.ecdh([])
 
-    res = p.ecdh(b'0' * 32)
+    res = p.ecdh(b"0" * 32)
     assert type(res) == bytes

--- a/tests/test_ecdsa.py
+++ b/tests/test_ecdsa.py
@@ -1,65 +1,63 @@
-import os
 import json
-import pytest
+import os
 from io import StringIO
+
+import pytest
 
 import secp256k1
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-DATA = os.path.join(HERE, 'data')
+DATA = os.path.join(HERE, "data")
 
 
 def test_ecdsa():
-    data = open(os.path.join(DATA, 'ecdsa_sig.json')).read()
-    vec = json.loads(data)['vectors']
+    data = open(os.path.join(DATA, "ecdsa_sig.json")).read()
+    vec = json.loads(data)["vectors"]
 
     inst = secp256k1.PrivateKey()
 
     for item in vec:
-        seckey = bytes(bytearray.fromhex(item['privkey']))
-        msg32 = bytes(bytearray.fromhex(item['msg']))
-        sig = bytes(bytearray.fromhex(item['sig'])[:-1])
+        seckey = bytes(bytearray.fromhex(item["privkey"]))
+        msg32 = bytes(bytearray.fromhex(item["msg"]))
+        sig = bytes(bytearray.fromhex(item["sig"])[:-1])
 
         inst.set_raw_privkey(seckey)
 
         sig_raw = inst.ecdsa_sign(msg32, raw=True)
         sig_check = inst.ecdsa_serialize(sig_raw)
         assert sig_check == sig
-        assert (inst.ecdsa_serialize(inst.ecdsa_deserialize(sig_check))
-                == sig_check)
+        assert inst.ecdsa_serialize(inst.ecdsa_deserialize(sig_check)) == sig_check
 
         assert inst.pubkey.ecdsa_verify(msg32, sig_raw, raw=True)
 
 
 def test_ecdsa_compact():
     key = secp256k1.PrivateKey()
-    raw_sig = key.ecdsa_sign(b'test')
-    assert key.pubkey.ecdsa_verify(b'test', raw_sig)
+    raw_sig = key.ecdsa_sign(b"test")
+    assert key.pubkey.ecdsa_verify(b"test", raw_sig)
 
     compact = key.ecdsa_serialize_compact(raw_sig)
     assert len(compact) == 64
 
     sig_raw = key.ecdsa_deserialize_compact(compact)
     assert key.ecdsa_serialize_compact(sig_raw) == compact
-    assert key.pubkey.ecdsa_verify(b'test', sig_raw)
+    assert key.pubkey.ecdsa_verify(b"test", sig_raw)
 
 
 def test_ecdsa_normalize():
     key = secp256k1.PrivateKey()
-    raw_sig = key.ecdsa_sign(b'hi')
+    raw_sig = key.ecdsa_sign(b"hi")
 
     had_to_normalize, normsig = key.ecdsa_signature_normalize(raw_sig)
     assert had_to_normalize is False
     assert key.ecdsa_serialize(normsig) == key.ecdsa_serialize(raw_sig)
-    assert (key.ecdsa_serialize_compact(normsig) ==
-            key.ecdsa_serialize_compact(raw_sig))
+    assert key.ecdsa_serialize_compact(normsig) == key.ecdsa_serialize_compact(raw_sig)
 
-    had_to_normalize, normsig = key.ecdsa_signature_normalize(
-        raw_sig, check_only=True)
+    had_to_normalize, normsig = key.ecdsa_signature_normalize(raw_sig, check_only=True)
     assert had_to_normalize is False
     assert normsig is None
 
-    sig = b'\xAA' + (b'\xFF' * 31) + b'\xAA' + (b'\xFF' * 31)
+    sig = b"\xAA" + (b"\xFF" * 31) + b"\xAA" + (b"\xFF" * 31)
     raw_sig = key.ecdsa_deserialize_compact(sig)
     normalized, normsig = key.ecdsa_signature_normalize(raw_sig)
     assert normalized is True
@@ -71,7 +69,7 @@ def test_ecdsa_normalize():
 
 def test_ecdsa_recover():
     if not secp256k1.HAS_RECOVERABLE:
-        pytest.skip('secp256k1_recovery not enabled, skipping')
+        pytest.skip("secp256k1_recovery not enabled, skipping")
         return
 
     class MyECDSA(secp256k1.ECDSA):
@@ -82,9 +80,9 @@ def test_ecdsa_recover():
     unrelated = MyECDSA()
 
     # Create a signature that allows recovering the public key.
-    recsig = privkey.ecdsa_sign_recoverable(b'hello')
+    recsig = privkey.ecdsa_sign_recoverable(b"hello")
     # Recover the public key.
-    pubkey = unrelated.ecdsa_recover(b'hello', recsig)
+    pubkey = unrelated.ecdsa_recover(b"hello", recsig)
     # Check that the recovered public key matches the one used
     # in privkey.pubkey.
     pubser = secp256k1.PublicKey(pubkey).serialize()
@@ -94,7 +92,7 @@ def test_ecdsa_recover():
     # we still recover the same public key.
     recsig_ser = unrelated.ecdsa_recoverable_serialize(recsig)
     recsig2 = unrelated.ecdsa_recoverable_deserialize(*recsig_ser)
-    pubkey2 = unrelated.ecdsa_recover(b'hello', recsig2)
+    pubkey2 = unrelated.ecdsa_recover(b"hello", recsig2)
     pubser2 = secp256k1.PublicKey(pubkey2).serialize()
     assert pubser == pubser2
 
@@ -105,22 +103,23 @@ def test_ecdsa_recover():
 def test_cli_ecdsa():
     parser, enc = secp256k1._parse_cli()
 
-    args = parser.parse_args(['privkey', '-p'])
+    args = parser.parse_args(["privkey", "-p"])
     out = StringIO()
     res = secp256k1._main_cli(args, out, enc)
     assert res == 0
-    raw_privkey, raw_pubkey = out.getvalue().strip().split('\n')
-    raw_pubkey = raw_pubkey.split(':')[1].strip()
+    raw_privkey, raw_pubkey = out.getvalue().strip().split("\n")
+    raw_pubkey = raw_pubkey.split(":")[1].strip()
 
-    args = parser.parse_args(['sign', '-k', raw_privkey, '-m', 'hi', '-p'])
+    args = parser.parse_args(["sign", "-k", raw_privkey, "-m", "hi", "-p"])
     out = StringIO()
     res = secp256k1._main_cli(args, out, enc)
     assert res == 0
-    signature, raw_pubkey2 = out.getvalue().strip().split('\n')
-    assert raw_pubkey2.split(':')[1].strip() == raw_pubkey
+    signature, raw_pubkey2 = out.getvalue().strip().split("\n")
+    assert raw_pubkey2.split(":")[1].strip() == raw_pubkey
 
     args = parser.parse_args(
-        ['checksig', '-p', raw_pubkey, '-m', 'hi', '-s', signature])
+        ["checksig", "-p", raw_pubkey, "-m", "hi", "-s", signature]
+    )
     out = StringIO()
     res = secp256k1._main_cli(args, out, enc)
     assert res == 0
@@ -128,7 +127,8 @@ def test_cli_ecdsa():
 
     # Pass an invalid signature.
     args = parser.parse_args(
-        ['checksig', '-p', raw_pubkey, '-m', 'hi', '-s', signature[:-2]])
+        ["checksig", "-p", raw_pubkey, "-m", "hi", "-s", signature[:-2]]
+    )
     out = StringIO()
     res = secp256k1._main_cli(args, out, enc)
     assert res == 1
@@ -137,29 +137,28 @@ def test_cli_ecdsa():
 
 def test_cli_ecdsa_recover():
     if not secp256k1.HAS_RECOVERABLE:
-        pytest.skip('secp256k1_recovery not enabled, skipping')
+        pytest.skip("secp256k1_recovery not enabled, skipping")
         return
     parser, enc = secp256k1._parse_cli()
 
-    args = parser.parse_args(['privkey', '-p'])
+    args = parser.parse_args(["privkey", "-p"])
     out = StringIO()
     res = secp256k1._main_cli(args, out, enc)
     assert res == 0
-    raw_privkey, raw_pubkey = out.getvalue().strip().split('\n')
-    raw_pubkey = raw_pubkey.split(':')[1].strip()
+    raw_privkey, raw_pubkey = out.getvalue().strip().split("\n")
+    raw_pubkey = raw_pubkey.split(":")[1].strip()
 
-    args = parser.parse_args(['signrec', '-k', raw_privkey, '-m', 'hi', '-p'])
+    args = parser.parse_args(["signrec", "-k", raw_privkey, "-m", "hi", "-p"])
     out = StringIO()
     res = secp256k1._main_cli(args, out, enc)
     assert res == 0
-    signature, raw_pubkey2 = out.getvalue().strip().split('\n')
-    assert raw_pubkey2.split(':')[1].strip() == raw_pubkey
+    signature, raw_pubkey2 = out.getvalue().strip().split("\n")
+    assert raw_pubkey2.split(":")[1].strip() == raw_pubkey
 
     sig_raw, recid = signature.split()
-    args = parser.parse_args(
-        ['recpub', '-m', 'hi', '-s', sig_raw, '-i', recid])
+    args = parser.parse_args(["recpub", "-m", "hi", "-s", sig_raw, "-i", recid])
     out = StringIO()
     res = secp256k1._main_cli(args, out, enc)
     assert res == 0
     recpub = out.getvalue().strip()
-    assert recpub.split(':')[1].strip() == raw_pubkey
+    assert recpub.split(":")[1].strip() == raw_pubkey

--- a/tests/test_err.py
+++ b/tests/test_err.py
@@ -1,29 +1,31 @@
-import pytest
 import hashlib
+
+import pytest
+
 import secp256k1
 
 
 def test_privkey():
     with pytest.raises(TypeError):
-        key = 'abc'
+        key = "abc"
         secp256k1.PrivateKey(key)
 
     with pytest.raises(TypeError):
-        key = bytearray.fromhex('a' * 32)  # This will result in 16 bytes.
+        key = bytearray.fromhex("a" * 32)  # This will result in 16 bytes.
         secp256k1.PrivateKey(bytes(key))
 
     with pytest.raises(Exception):
-        secp256k1.PrivateKey(bytes(bytearray.fromhex('0' * 64)))
+        secp256k1.PrivateKey(bytes(bytearray.fromhex("0" * 64)))
 
     with pytest.raises(Exception):
-        secp256k1.PrivateKey(bytes(bytearray.fromhex('F' * 64)))
+        secp256k1.PrivateKey(bytes(bytearray.fromhex("F" * 64)))
 
     with pytest.raises(Exception):
         # This is a good raw key, but here it's being passed as serialized.
-        secp256k1.PrivateKey(b'1' * 32, raw=False)
+        secp256k1.PrivateKey(b"1" * 32, raw=False)
 
     # "good" key, should be fine.
-    assert secp256k1.PrivateKey(b'1' * 32)
+    assert secp256k1.PrivateKey(b"1" * 32)
 
 
 def test_publickey():
@@ -33,21 +35,21 @@ def test_publickey():
         # In Python 2 this will not raise a TypeError
         # since bytes is an alias to str, instead it will fail
         # during deserialization.
-        secp256k1.PublicKey('abc', raw=True)
+        secp256k1.PublicKey("abc", raw=True)
     with pytest.raises(Exception):
         secp256k1.PublicKey([], raw=True)
 
     with pytest.raises(Exception):
         # Invalid size.
-        secp256k1.PublicKey(b'abc', raw=True)
+        secp256k1.PublicKey(b"abc", raw=True)
 
     with pytest.raises(Exception):
         # Invalid public key.
-        secp256k1.PublicKey(b'a' * 33, raw=True)
+        secp256k1.PublicKey(b"a" * 33, raw=True)
 
     # Invalid usage: passing a raw public key but not specifying raw=True.
     with pytest.raises(TypeError):
-        secp256k1.PublicKey(b'a' * 33)
+        secp256k1.PublicKey(b"a" * 33)
 
     # No public key.
     assert secp256k1.PublicKey()
@@ -65,15 +67,17 @@ def test_publickey():
 
 
 def test_ecdsa():
-    rawkey = (b'\xc9\xa9)Z\xf8Er\x97\x8b\xa23\x1f\xf7\xb6\x82qQ\xdc9\xc1'
-              b'\x1d\xac6\xfd\xeb\x11\x05\xb1\xdf\x86\xb3\xe6')
+    rawkey = (
+        b"\xc9\xa9)Z\xf8Er\x97\x8b\xa23\x1f\xf7\xb6\x82qQ\xdc9\xc1"
+        b"\x1d\xac6\xfd\xeb\x11\x05\xb1\xdf\x86\xb3\xe6"
+    )
     priv = secp256k1.PrivateKey(rawkey)
     with pytest.raises(Exception):
         # Bad digest function (doesn't produce 256 bits).
-        priv.ecdsa_sign(b'hi', digest=hashlib.sha1)
+        priv.ecdsa_sign(b"hi", digest=hashlib.sha1)
 
-    raw_sig = priv.ecdsa_sign(b'hi')
-    assert priv.pubkey.ecdsa_verify(b'hi', raw_sig)
+    raw_sig = priv.ecdsa_sign(b"hi")
+    assert priv.pubkey.ecdsa_verify(b"hi", raw_sig)
 
     with pytest.raises(AssertionError):
         sig = priv.ecdsa_serialize(raw_sig)[:-1]
@@ -82,13 +86,13 @@ def test_ecdsa():
     sig = priv.ecdsa_serialize(raw_sig)
     sig = sig[:-1] + bytes(sig[0:1])  # Assuming sig[0] != sig[-1].
     invalid_sig = priv.ecdsa_deserialize(sig)
-    assert not priv.pubkey.ecdsa_verify(b'hi', invalid_sig)
+    assert not priv.pubkey.ecdsa_verify(b"hi", invalid_sig)
 
 
 def test_ecdsa_compact():
     key = secp256k1.PrivateKey()
 
-    raw_sig = key.ecdsa_sign(b'hi')
+    raw_sig = key.ecdsa_sign(b"hi")
     with pytest.raises(TypeError):
         # Should pass a compact serialization.
         key.ecdsa_deserialize_compact(raw_sig)
@@ -101,12 +105,12 @@ def test_ecdsa_compact():
 
 def test_ecdsa_recoverable():
     if not secp256k1.HAS_RECOVERABLE:
-        pytest.skip('secp256k1_recovery not enabled, skipping')
+        pytest.skip("secp256k1_recovery not enabled, skipping")
         return
 
-    key = '32a8935ffdb984a498b0f7ac8943e0d2ac084e81c809595fd19fde41522f1837'
+    key = "32a8935ffdb984a498b0f7ac8943e0d2ac084e81c809595fd19fde41522f1837"
     priv = secp256k1.PrivateKey(bytes(bytearray.fromhex(key)))
-    sig = priv.ecdsa_sign_recoverable(b'hi')
+    sig = priv.ecdsa_sign_recoverable(b"hi")
     sig_ser, rec_id = priv.ecdsa_recoverable_serialize(sig)
     assert rec_id == 1
 
@@ -118,18 +122,18 @@ def test_ecdsa_recoverable():
     sig = priv.ecdsa_recoverable_deserialize(sig_ser, 2)
     with pytest.raises(Exception):
         # Now try to recover the public key.
-        priv.ecdsa_recover(b'hi', sig)
+        priv.ecdsa_recover(b"hi", sig)
 
     # Invalid size.
     with pytest.raises(Exception):
-        priv.ecdsa_recoverable_deserialize(b'hello', 0)
+        priv.ecdsa_recoverable_deserialize(b"hello", 0)
 
 
 def test_tweak():
     key = secp256k1.PrivateKey()
 
     # Tweak out of range
-    scalar = b'\xFF' * 32
+    scalar = b"\xFF" * 32
     with pytest.raises(Exception):
         key.tweak_mul(scalar)
     with pytest.raises(Exception):

--- a/tests/test_pubkey.py
+++ b/tests/test_pubkey.py
@@ -1,23 +1,23 @@
-import os
 import json
+import os
 from io import StringIO
 
 import secp256k1
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-DATA = os.path.join(HERE, 'data')
+DATA = os.path.join(HERE, "data")
 
 
 def test_pubkey_from_privkey():
-    data = open(os.path.join(DATA, 'pubkey.json')).read()
-    vec = json.loads(data)['vectors']
+    data = open(os.path.join(DATA, "pubkey.json")).read()
+    vec = json.loads(data)["vectors"]
 
     inst = secp256k1.PrivateKey()
 
     for item in vec:
-        seckey = bytes(bytearray.fromhex(item['seckey']))
-        pubkey_uncp = bytes(bytearray.fromhex(item['pubkey']))
-        pubkey_comp = bytes(bytearray.fromhex(item['compressed']))
+        seckey = bytes(bytearray.fromhex(item["seckey"]))
+        pubkey_uncp = bytes(bytearray.fromhex(item["pubkey"]))
+        pubkey_comp = bytes(bytearray.fromhex(item["compressed"]))
 
         inst.set_raw_privkey(seckey)
 
@@ -48,18 +48,18 @@ def test_pubkey_combine():
 def test_cli():
     parser, enc = secp256k1._parse_cli()
 
-    args = parser.parse_args(['privkey', '-p'])
+    args = parser.parse_args(["privkey", "-p"])
     out = StringIO()
     res = secp256k1._main_cli(args, out, enc)
     assert res == 0
-    raw_privkey, raw_pubkey = out.getvalue().strip().split('\n')
-    raw_pubkey = raw_pubkey.split(':')[1].strip()
+    raw_privkey, raw_pubkey = out.getvalue().strip().split("\n")
+    raw_pubkey = raw_pubkey.split(":")[1].strip()
 
-    args = parser.parse_args(['privkey', '-k', raw_privkey, '-p'])
+    args = parser.parse_args(["privkey", "-k", raw_privkey, "-p"])
     out = StringIO()
     res = secp256k1._main_cli(args, out, enc)
     assert res == 0
-    raw_privkey2, raw_pubkey2 = out.getvalue().strip().split('\n')
-    raw_pubkey2 = raw_pubkey2.split(':')[1].strip()
+    raw_privkey2, raw_pubkey2 = out.getvalue().strip().split("\n")
+    raw_pubkey2 = raw_pubkey2.split(":")[1].strip()
     assert raw_privkey2 == raw_privkey
     assert raw_pubkey2 == raw_pubkey2

--- a/tests/test_schnorr.py
+++ b/tests/test_schnorr.py
@@ -5,15 +5,13 @@ import secp256k1
 
 def test_schnorr_simple():
     if not secp256k1.HAS_SCHNORR:
-        pytest.skip('secp256k1_schnorr not enabled, skipping')
+        pytest.skip("secp256k1_schnorr not enabled, skipping")
         return
 
     inst = secp256k1.PrivateKey()
-    raw_sig = inst.schnorr_sign(b'hello', 'test_schnorr_simple')
+    raw_sig = inst.schnorr_sign(b"hello", "test_schnorr_simple")
 
-    assert inst.pubkey.schnorr_verify(b'hello', raw_sig, 'test_schnorr_simple')
-    assert not inst.pubkey.schnorr_verify(b'hello', raw_sig,
-                                          'test_schnorr_simple2')
+    assert inst.pubkey.schnorr_verify(b"hello", raw_sig, "test_schnorr_simple")
+    assert not inst.pubkey.schnorr_verify(b"hello", raw_sig, "test_schnorr_simple2")
     key2 = secp256k1.PrivateKey()
-    assert not key2.pubkey.schnorr_verify(b'hello', raw_sig,
-                                          'test_schnorr_simple')
+    assert not key2.pubkey.schnorr_verify(b"hello", raw_sig, "test_schnorr_simple")

--- a/tests/test_tweak.py
+++ b/tests/test_tweak.py
@@ -1,4 +1,5 @@
 import pytest
+
 import secp256k1
 
 
@@ -6,19 +7,19 @@ def test_pubkey_tweak():
     inst = secp256k1.PrivateKey()
     pub = inst.pubkey
 
-    scalar = [b'\x01' * 32]
+    scalar = [b"\x01" * 32]
     with pytest.raises(TypeError):
         pub.tweak_add(scalar)
     with pytest.raises(TypeError):
         pub.tweak_mul(scalar)
 
-    scalar = b'\x01' * 31
+    scalar = b"\x01" * 31
     with pytest.raises(TypeError):
         pub.tweak_add(scalar)
     with pytest.raises(TypeError):
         pub.tweak_mul(scalar)
 
-    scalar = scalar + b'\x01'
+    scalar = scalar + b"\x01"
     res = pub.tweak_add(scalar)
     assert isinstance(res, secp256k1.PublicKey)
     assert res.serialize() != pub.serialize()
@@ -27,18 +28,18 @@ def test_pubkey_tweak():
 def test_privkey_tweak():
     key = secp256k1.PrivateKey()
 
-    scalar = [b'\x01' * 32]
+    scalar = [b"\x01" * 32]
     with pytest.raises(TypeError):
         key.tweak_add(scalar)
     with pytest.raises(TypeError):
         key.tweak_mul(scalar)
 
-    scalar = b'\x01' * 31
+    scalar = b"\x01" * 31
     with pytest.raises(TypeError):
         key.tweak_add(scalar)
     with pytest.raises(TypeError):
         key.tweak_mul(scalar)
 
-    scalar = scalar + b'\x01'
+    scalar = scalar + b"\x01"
     res = key.tweak_add(scalar)
     assert isinstance(res, bytes) and len(res) == 32


### PR DESCRIPTION
secp256k1 being a clean and lean library, it would deserve clean and lean coding standard.
https://github.com/psf/black
https://pycqa.github.io/isort/

I know global formatting PRs are often rejected, but considering that this python code is just glue code, in this case it might be received