### PR TITLE
setup.py: Fix invalid definition of bdist_wheel command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,16 +104,6 @@ class sdist(_sdist):
         download_library(self)
         _sdist.run(self)
 
-
-if _bdist_wheel:
-    class bdist_wheel(_bdist_wheel):
-        def run(self):
-            download_library(self)
-            _bdist_wheel.run(self)
-else:
-    bdist_wheel = None
-
-
 class Distribution(_Distribution):
     def has_c_libraries(self):
         return not has_system_lib()
@@ -264,6 +254,21 @@ class develop(_develop):
 with io.open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
+cmdclass = {
+    'build_clib': build_clib,
+    'build_ext': build_ext,
+    'develop': develop,
+    'egg_info': egg_info,
+    'sdist': sdist,
+}
+
+if _bdist_wheel:
+    class bdist_wheel(_bdist_wheel):
+        def run(self):
+            download_library(self)
+            _bdist_wheel.run(self)
+    cmdclass['bdist_wheel'] = bdist_wheel
+
 setup(
     name="secp256k1",
     version="0.14.0",
@@ -290,14 +295,7 @@ setup(
         "_cffi_build/build.py:ffi"
     ],
 
-    cmdclass={
-        'build_clib': build_clib,
-        'build_ext': build_ext,
-        'develop': develop,
-        'egg_info': egg_info,
-        'sdist': sdist,
-        'bdist_wheel': bdist_wheel
-    },
+    cmdclass=cmdclass,
     distclass=Distribution,
     zip_safe=False,
 


### PR DESCRIPTION
Don't set cmdclass["bdist_wheel"] to None if bdist_wheel is unavailable. This prevents installation error:

TypeError: 'NoneType' object is not callable

Refs #7