### PR TITLE
ci: Modernize cibuildwheel with pyproject.toml and multi-platform support

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,10 +28,10 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8
       run: |
-        flake8 . --count --show-source --statistics
+        flake8 . --count --show-source --statistics --exclude=libsecp256k1,.venv,.eggs,build
     - name: Install self
       run: |
         pip install .
     - name: Test with pytest
       run: |
-        pytest
+        pytest tests/ -v

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -15,12 +15,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-22.04
-          - ubuntu-22.04-arm    # Native ARM64 runner
-          - macos-14
-          - windows-2022
-          - windows-11-arm      # Native Windows ARM64 runner
+        include:
+          - os: ubuntu-22.04
+            archs: x86_64
+          - os: ubuntu-22.04-arm
+            archs: aarch64
+          - os: macos-14
+            archs: universal2
+          - os: windows-2022
+            archs: AMD64
+          - os: windows-11-arm
+            archs: ARM64
 
     steps:
       - uses: actions/checkout@v4
@@ -33,6 +38,8 @@ jobs:
         uses: pypa/cibuildwheel@v2.23
         with:
           output-dir: wheelhouse
+        env:
+          CIBW_ARCHS: ${{ matrix.archs }}
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -20,6 +20,7 @@ jobs:
           - ubuntu-22.04-arm    # Native ARM64 runner
           - macos-14
           - windows-2022
+          - windows-11-arm      # Native Windows ARM64 runner
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
+          - ubuntu-22.04-arm    # Native ARM64 runner
           - macos-14
           - windows-2022
 
@@ -26,13 +27,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
-      # Set up QEMU for Linux ARM64 emulation
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.23

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -17,7 +17,8 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-14      # Apple Silicon (M1)
+          - macos-14
+          - windows-2022
 
     steps:
       - uses: actions/checkout@v4
@@ -26,35 +27,17 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.23.3
+      # Set up QEMU for Linux ARM64 emulation
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
 
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
-        env:
-          # Build for CPython 3.9-3.13
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
-          
-          # Skip PyPy and musllinux
-          CIBW_SKIP: "pp* *-musllinux*"
-          
-          # Use the `build` frontend
-          CIBW_BUILD_FRONTEND: "build"
-          
-          # Ensure setuptools is available (required by CFFI on Python 3.12+)
-          CIBW_BEFORE_BUILD: pip install setuptools
-          
-          # Linux: clean build directory
-          CIBW_BEFORE_ALL_LINUX: |
-            rm -rf build .eggs
-          
-          # macOS: clean build directory
-          CIBW_BEFORE_ALL_MACOS: |
-            rm -rf build .eggs
-          
-          # Build for native architecture on each runner
-          CIBW_ARCHS_LINUX: "auto"
-          CIBW_ARCHS_MACOS: "native"
+        uses: pypa/cibuildwheel@v2.23
+        with:
+          output-dir: wheelhouse
 
       - uses: actions/upload-artifact@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=61.0", "cffi>=1.3.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+# Build CPython 3.9-3.13
+build = "cp39-* cp310-* cp311-* cp312-* cp313-*"
+
+# Skip PyPy (CFFI builds are complex) and 32-bit builds (low demand)
+skip = "pp* *-win32 *-manylinux_i686 *-musllinux_i686"
+
+# Use the build frontend (PEP 517)
+build-frontend = "build"
+
+# Ensure setuptools is available (required by CFFI on Python 3.12+)
+before-build = "pip install setuptools"
+
+# Test configuration
+test-requires = "pytest"
+test-command = "pytest {project}/tests -v"
+
+[tool.cibuildwheel.linux]
+# Clean build directory before building
+before-all = "rm -rf build .eggs"
+
+# Build for x86_64 and aarch64
+archs = ["x86_64", "aarch64"]
+
+# Skip tests on emulated architectures (too slow/flaky)
+test-skip = "*-manylinux_aarch64"
+
+[tool.cibuildwheel.macos]
+# Clean build directory before building
+before-all = "rm -rf build .eggs"
+
+# Build universal2 wheels (Intel + Apple Silicon)
+archs = ["universal2"]
+
+[tool.cibuildwheel.windows]
+# Build for 64-bit only
+archs = ["AMD64"]
+
+# Clean build directory before building
+before-all = "if exist build rmdir /s /q build && if exist .eggs rmdir /s /q .eggs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,8 @@ test-command = "pytest {project}/tests -v"
 # Clean build directory before building
 before-all = "rm -rf build .eggs"
 
-# Build for x86_64 and aarch64
-archs = ["x86_64", "aarch64"]
-
-# Skip tests on emulated architectures (too slow/flaky)
-test-skip = "*-manylinux_aarch64"
+# Build for native architecture (we use separate runners for x86_64 and aarch64)
+archs = ["native"]
 
 [tool.cibuildwheel.macos]
 # Clean build directory before building

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,20 +23,11 @@ test-command = "pytest {project}/tests -v"
 # Clean build directory before building
 before-all = "rm -rf build .eggs"
 
-# Build for native architecture (we use separate runners for x86_64 and aarch64)
-archs = ["native"]
-
 [tool.cibuildwheel.macos]
 # Clean build directory before building
 before-all = "rm -rf build .eggs"
 
-# Build universal2 wheels (Intel + Apple Silicon)
-archs = ["universal2"]
-
 [tool.cibuildwheel.windows]
-# Build for 64-bit x86 and ARM64
-archs = ["AMD64", "ARM64"]
-
 # Skip tests on ARM64 (no ARM64 Python available on CI runners yet)
 test-skip = "*-win_arm64"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,11 @@ before-all = "rm -rf build .eggs"
 archs = ["universal2"]
 
 [tool.cibuildwheel.windows]
-# Build for 64-bit only
-archs = ["AMD64"]
+# Build for 64-bit x86 and ARM64
+archs = ["AMD64", "ARM64"]
+
+# Skip tests on ARM64 (no ARM64 Python available on CI runners yet)
+test-skip = "*-win_arm64"
 
 # Clean build directory before building
 before-all = "if exist build rmdir /s /q build && if exist .eggs rmdir /s /q .eggs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ build-frontend = "build"
 before-build = "pip install setuptools"
 
 # Test configuration
-test-requires = "pytest"
+test-requires = ["pytest", "setuptools"]
 test-command = "pytest {project}/tests -v"
 
 [tool.cibuildwheel.linux]

--- a/setup.py
+++ b/setup.py
@@ -161,6 +161,18 @@ class build_clib(_build_clib):
             "-DSECP256K1_ENABLE_MODULE_RECOVERY=1",
         ]
 
+        # Support macOS universal2 builds by setting CMAKE_OSX_ARCHITECTURES
+        # when ARCHFLAGS is set (typically by cibuildwheel)
+        archflags = os.environ.get('ARCHFLAGS', '')
+        if archflags:
+            archs = []
+            if '-arch x86_64' in archflags:
+                archs.append('x86_64')
+            if '-arch arm64' in archflags:
+                archs.append('arm64')
+            if archs:
+                cmd.append("-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs)))
+
         if not os.environ.get('SECP_BUNDLED_NO_EXPERIMENTAL'):
             log.info("Building experimental")
             cmd.extend([

--- a/setup.py
+++ b/setup.py
@@ -241,7 +241,7 @@ with io.open('README.md', encoding='utf-8') as f:
 
 setup(
     name="secp256k1",
-    version="0.14.0",
+    version="0.14.1",
 
     description='FFI bindings to libsecp256k1',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,8 @@ class build_clib(_build_clib):
             if '-arch arm64' in archflags:
                 archs.append('arm64')
             if archs:
-                cmd.append("-DCMAKE_OSX_ARCHITECTURES={}".format(";".join(archs)))
+                arch_str = ";".join(archs)
+                cmd.append("-DCMAKE_OSX_ARCHITECTURES={}".format(arch_str))
 
         if not os.environ.get('SECP_BUNDLED_NO_EXPERIMENTAL'):
             log.info("Building experimental")

--- a/tests/test_custom_nonce.py
+++ b/tests/test_custom_nonce.py
@@ -6,54 +6,60 @@ import sys
 import tempfile
 
 # ignore_cleanup_errors was added in Python 3.10
-if sys.version_info < (3, 10):
-    pytest.skip(
-        "ignore_cleanup_errors requires Python 3.10+", allow_module_level=True
-    )
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 10),
+    reason="ignore_cleanup_errors requires Python 3.10+"
+)
 
-HERE = os.path.dirname(os.path.abspath(__file__))
-DATA = os.path.join(HERE, 'data')
+if sys.version_info >= (3, 10):
+    from cffi import FFI
 
-from cffi import FFI  # noqa: E402
+    HERE = os.path.dirname(os.path.abspath(__file__))
+    DATA = os.path.join(HERE, 'data')
 
-ffi = FFI()
-ffi.cdef('static int nonce_function_rand(unsigned char *nonce32,'
-         'const unsigned char *msg32,const unsigned char *key32,'
-         'const unsigned char *algo16,void *data,unsigned int attempt);')
+    ffi = FFI()
+    ffi.cdef('static int nonce_function_rand(unsigned char *nonce32,'
+             'const unsigned char *msg32,const unsigned char *key32,'
+             'const unsigned char *algo16,void *data,unsigned int attempt);')
 
-# The most elementary conceivable nonce function, acting
-# as a passthrough: user provides random data which must be
-# a valid scalar nonce. This is not ideal,
-# since libsecp256k1 expects the nonce output from
-# this function to result in a valid sig (s!=0), and will
-# increment the counter ("attempt") and try again if it fails;
-# since we don't increment the counter here, that will not succeed.
-# Of course the likelihood of such an error is infinitesimal.
-# TLDR this is not intended to be used in real life; use
-# deterministic signatures.
-ffi.set_source("_noncefunc",
-               """
-static int nonce_function_rand(unsigned char *nonce32,
-const unsigned char *msg32,
-const unsigned char *key32,
-const unsigned char *algo16,
-void *data,
-unsigned int attempt)
-{
-memcpy(nonce32,data,32);
-return 1;
-}
-               """)
+    # The most elementary conceivable nonce function, acting
+    # as a passthrough: user provides random data which must be
+    # a valid scalar nonce. This is not ideal,
+    # since libsecp256k1 expects the nonce output from
+    # this function to result in a valid sig (s!=0), and will
+    # increment the counter ("attempt") and try again if it fails;
+    # since we don't increment the counter here, that will not succeed.
+    # Of course the likelihood of such an error is infinitesimal.
+    # TLDR this is not intended to be used in real life; use
+    # deterministic signatures.
+    ffi.set_source("_noncefunc",
+                   """
+    static int nonce_function_rand(unsigned char *nonce32,
+    const unsigned char *msg32,
+    const unsigned char *key32,
+    const unsigned char *algo16,
+    void *data,
+    unsigned int attempt)
+    {
+    memcpy(nonce32,data,32);
+    return 1;
+    }
+                   """)
 
-# XXX: ignore_cleanup_errors because deletion fails on Windows
-with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as build_temp:
-    ffi.compile(tmpdir=build_temp)
+    # XXX: ignore_cleanup_errors because deletion fails on Windows
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as build_temp:
+        ffi.compile(tmpdir=build_temp)
 
-    # Make sure we can find our nonce.
-    sys.path.append(build_temp)
+        # Make sure we can find our nonce.
+        sys.path.append(build_temp)
 
-    import _noncefunc  # noqa: E402
-    from _noncefunc import ffi  # noqa: E402
+        import _noncefunc
+        from _noncefunc import ffi
+else:
+    HERE = os.path.dirname(os.path.abspath(__file__))
+    DATA = os.path.join(HERE, 'data')
+    _noncefunc = None
+    ffi = None
 
 
 def test_ecdsa_with_custom_nonce():


### PR DESCRIPTION
This PR modernizes the wheel building infrastructure:

## Changes
- Add `pyproject.toml` with cibuildwheel configuration (modern approach)
- Use official `pypa/cibuildwheel` GitHub Action
- Upgrade libsecp256k1 to v0.6.0 and switch to CMake build (from PR #23)

## Platforms enabled
| Platform | Architectures | Notes |
|----------|--------------|-------|
| Linux | x86_64, aarch64 | aarch64 via QEMU emulation |
| macOS | universal2 | Intel + Apple Silicon in one wheel |
| Windows | AMD64 | Now possible with CMake build |

## Python versions
- CPython 3.9, 3.10, 3.11, 3.12, 3.13

## Skipped
- PyPy (CFFI builds are complex)
- 32-bit builds (low demand)
- Tests on emulated aarch64 (too slow)

Closes #22
Closes #21 
Closes #20 
Closes #7 
Closes #15 