### PR TITLE
Update to latest libsecp256k1 v0.7.1

### DIFF
--- a/_cffi_build/secp256k1.h
+++ b/_cffi_build/secp256k1.h
@@ -133,7 +133,7 @@ int secp256k1_ec_pubkey_create(
     const unsigned char *seckey
 );
 
-int secp256k1_ec_privkey_tweak_add(
+int secp256k1_ec_seckey_tweak_add(
     const secp256k1_context* ctx,
     unsigned char *seckey,
     const unsigned char *tweak
@@ -145,7 +145,7 @@ int secp256k1_ec_pubkey_tweak_add(
     const unsigned char *tweak
 );
 
-int secp256k1_ec_privkey_tweak_mul(
+int secp256k1_ec_seckey_tweak_mul(
     const secp256k1_context* ctx,
     unsigned char *seckey,
     const unsigned char *tweak

--- a/secp256k1/__init__.py
+++ b/secp256k1/__init__.py
@@ -319,14 +319,14 @@ class PrivateKey(ECDSA):
         Tweak the current private key by adding a 32 byte scalar
         to it and return a new raw private key composed of 32 bytes.
         """
-        return _tweak_private(self, lib.secp256k1_ec_privkey_tweak_add, scalar)
+        return _tweak_private(self, lib.secp256k1_ec_seckey_tweak_add, scalar)
 
     def tweak_mul(self, scalar):
         """
         Tweak the current private key by multiplying it by a 32 byte scalar
         and return a new raw private key composed of 32 bytes.
         """
-        return _tweak_private(self, lib.secp256k1_ec_privkey_tweak_mul, scalar)
+        return _tweak_private(self, lib.secp256k1_ec_seckey_tweak_mul, scalar)
 
     def ecdsa_sign(self, msg, raw=False, digest=hashlib.sha256,
                    custom_nonce=None):

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ from setup_support import absolute, has_system_lib  # noqa: E402
 # Version of libsecp256k1 to download if none exists in the `libsecp256k1`
 # directory
 LIB_TARBALL_URL = ("https://github.com/bitcoin-core/secp256k1/archive/"
-                   "refs/tags/v0.6.0"
+                   "refs/tags/v0.7.1"
                    ".tar.gz")
 
 


### PR DESCRIPTION
Some deprecated tweaking function aliases have been removed in v0.7.0, so the first commit adapts the API calls accordingly before bumping the tarball version.